### PR TITLE
Changes to FindPAPI.cmake for building on EC systems

### DIFF
--- a/cmake/FindPAPI.cmake
+++ b/cmake/FindPAPI.cmake
@@ -21,10 +21,14 @@ if (UNIX)
 
     find_path(PAPI_INCLUDE_DIR
             NAMES papi.h
+            HINTS ENV PAPI_DIR
+            PATH_SUFFIXES include
             REQUIRED)
 
     find_library(PAPI_LIBRARY
             NAMES papi
+            HINTS ENV PAPI_DIR
+            PATH_SUFFIXES lib
             REQUIRED)
 
     include(FindPackageHandleStandardArgs)
@@ -41,9 +45,9 @@ if (UNIX)
 
     # Make PAPI an imported target and also include its public header papi.h
     if (PAPI_FOUND AND NOT TARGET PAPI::PAPI)
-        add_library(PAPI::PAPI SHARED IMPORTED)
+        add_library(PAPI::PAPI STATIC IMPORTED)
         set_target_properties(PAPI::PAPI PROPERTIES IMPORTED_LOCATION ${PAPI_LIBRARY})
-        target_include_directories(PAPI::PAPI INTERFACE ${PAPI_INCLUDE_DIR})
+        include_directories(${PAPI_INCLUDE_DIR})
     endif ()
 
 else ()


### PR DESCRIPTION
This change amends cmake/FindPAPI.cmake to support building
on Environment Canada systems.  In particular:

* The cmake file now uses PAPI_DIR as a directory search
  path for the include/ and lib/ directories
* The resulting include path is added with
  include_directories rather than target_include_directories
  to support the slightly older version of CMake used on EC
  systems.  This version does not support
  target_include_directories for an imported target.
* PAPI is included as a static rather than dynamic library, to
  better reflect the use on the "back-end" machines.