### PR TITLE
Flexible events

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ In the CMakeLists.txt add:
 
 At the moment, the Stopwatch interface should be used like so:
 1. call `stopwatch_init` to initialize the appropriate structures and start the monotonic event timers. The events to be
-   measured is specified via the `STOPWATCH_EVENTS` environment variable. Each event should be delimited with a colon `:`.
+   measured is specified via the `STOPWATCH_EVENTS` environment variable. Each event should be delimited with a comma `,`.
    The events that can be added can be initially queried via the utility `papi_avail` that PAPI provides. If the
    `STOPWATCH_EVENTS` variable is unset, the default events of `PAPI_TOT_CYC` and `PAPI_TOT_INS` are used.
 2. wrap the function(s) to measure with the calls to `stopwatch_record_start_measurements` and 
@@ -109,7 +109,7 @@ int main() {
 Before running the binary, the environment variable `STOPWATCH_EVENTS` must be set. In this case it should be set to
 `PAPI_RES_STL:PAPI_L1_TCM`.
 ```shell
-export STOPWATCH_EVENTS=PAPI_RES_STL:PAPI_L1_TCM
+export STOPWATCH_EVENTS=PAPI_RES_STL,PAPI_L1_TCM
 ```
 
 The result should look similar to this:

--- a/examples/examples_c/matmul.c
+++ b/examples/examples_c/matmul.c
@@ -32,8 +32,7 @@ int main() {
 
   struct StopwatchMeasurementResult result; // structure to hold the results
 
-  const enum StopwatchEvents events[] = {TOTAL_CYCLES, L1_CACHE_MISS};
-  if (stopwatch_init(events, 2) != STOPWATCH_OK) {
+  if (stopwatch_init() != STOPWATCH_OK) {
     printf("Error initializing stopwatch\n");
     return -1;
   }

--- a/examples/examples_c/matmul_loop.c
+++ b/examples/examples_c/matmul_loop.c
@@ -7,8 +7,8 @@
 void row_major(int N, float A[N][N], float B[N][N], float C[N][N]);
 
 int main() {
-  //const enum StopwatchEvents events[] = {SP_FLOAT_OPS};
-  if (stopwatch_init(/*events, 1*/) != STOPWATCH_OK) {
+
+  if (stopwatch_init() != STOPWATCH_OK) {
     printf("Error initializing stopwatch\n");
     exit(-1);
   }

--- a/examples/examples_c/matmul_loop.c
+++ b/examples/examples_c/matmul_loop.c
@@ -7,8 +7,8 @@
 void row_major(int N, float A[N][N], float B[N][N], float C[N][N]);
 
 int main() {
-  const enum StopwatchEvents events[] = {SP_FLOAT_OPS};
-  if (stopwatch_init(events, 1) != STOPWATCH_OK) {
+  //const enum StopwatchEvents events[] = {SP_FLOAT_OPS};
+  if (stopwatch_init(/*events, 1*/) != STOPWATCH_OK) {
     printf("Error initializing stopwatch\n");
     exit(-1);
   }

--- a/examples/examples_fortran/heat_transfer.F90
+++ b/examples/examples_fortran/heat_transfer.F90
@@ -9,9 +9,6 @@ program heat_transfer
     integer(kind=4), parameter :: num_time_steps = 1000
     integer(kind=4), parameter :: num_elem = 1000 ! Number of finite elements per side of the plane
     real(kind=8), dimension(num_elem, num_elem) :: plane
-    integer(c_size_t), parameter :: num_events = 2
-    integer(kind=kind(L1_CACHE_MISS)), dimension(num_events), parameter :: events = (/TOTAL_CYCLES, L1_CACHE_MISS /)
-
 
     integer :: ret_val
     integer :: i
@@ -23,7 +20,7 @@ program heat_transfer
     plane(1,:) = 10.0
 
     ! Initialize stopwatch
-    ret_val = Fstopwatch_init(events, num_events)
+    ret_val = Fstopwatch_init()
     if (ret_val /= STOPWATCH_OK) then
         print *, "Error initializing stopwatch"
         stop -1

--- a/include/stopwatch/fstopwatch.F03
+++ b/include/stopwatch/fstopwatch.F03
@@ -25,24 +25,9 @@ module mod_stopwatch
         integer(c_int) event_names(STOPWATCH_MAX_EVENTS)
     end type StopwatchMeasurementResult
 
-    enum, bind(c)
-        enumerator :: L1_CACHE_MISS = 1
-        enumerator :: L2_CACHE_MISS
-        enumerator :: L3_CACHE_MISS
-        enumerator :: BRANCH_MISPREDICT
-        enumerator :: BRANCH_PREDICT
-        enumerator :: CYCLES_STALLED_RESOURCE
-        enumerator :: TOTAL_CYCLES
-        enumerator :: SP_FLOAT_OPS
-        enumerator :: DP_FLOAT_OPS
-    end enum
-
     interface
-        integer(c_int) function Fstopwatch_init(events_to_add, num_of_events) bind(c, name = 'stopwatch_init')
-            import :: c_int, c_size_t
-            ! Since enumerations are just integers, we make sure that the integer can hold the defined enumeration integer
-            integer(kind(L1_CACHE_MISS)), intent(in) :: events_to_add(*)
-            integer(c_size_t), value, intent(in) :: num_of_events
+        integer(c_int) function Fstopwatch_init() bind(c, name = 'stopwatch_init')
+            import :: c_int
         end function Fstopwatch_init
 
         subroutine Fstopwatch_destroy() bind(c, name = 'stopwatch_destroy')

--- a/include/stopwatch/stopwatch.h
+++ b/include/stopwatch/stopwatch.h
@@ -10,21 +10,6 @@
 #define NULL_TERM_MAX_ROUTINE_NAME_LEN 16
 
 // =====================================================================================================================
-// Valid Events
-// =====================================================================================================================
-enum StopwatchEvents {
-  L1_CACHE_MISS = 1,
-  L2_CACHE_MISS,
-  L3_CACHE_MISS,
-  BRANCH_MISPREDICT,
-  BRANCH_PREDICT,
-  CYCLES_STALLED_RESOURCE,
-  TOTAL_CYCLES,
-  SP_FLOAT_OPS,
-  DP_FLOAT_OPS
-};
-
-// =====================================================================================================================
 // Structure holding results for a specific entry
 // =====================================================================================================================
 struct StopwatchMeasurementResult {
@@ -44,7 +29,7 @@ struct StopwatchMeasurementResult {
 // Initializes the event timers. Currently the events that are measured are hard coded. This will also start the
 // monotonic measurement clock as currently it is assumed that consumers would immediately start the clock after
 // initializing the stopwatch structure.
-int stopwatch_init(const enum StopwatchEvents *events_to_add, size_t num_of_events);
+int stopwatch_init();
 
 // Stops the monotonic event timers and cleans up resources used by the timer. Interestingly valgrind still reports a
 // memory leak with the PAPI specific resources

--- a/src/stopwatch.c
+++ b/src/stopwatch.c
@@ -288,7 +288,7 @@ static int set_events() {
   if (event_env_val) {
     // A copy is made as strtok_r mutates the arguments
     char* env_var_copy_elem = strdup(event_env_val); // Copy of the env var for use to parse each element
-    char* delimiter = ":";
+    char* delimiter = ",";
     char* save_ptr;
 
     for(char* token = strtok_r(env_var_copy_elem, delimiter, &save_ptr); token != NULL; token = strtok_r(NULL, delimiter, &save_ptr)) {

--- a/test/stopwatch_initializing_tests.c
+++ b/test/stopwatch_initializing_tests.c
@@ -7,21 +7,17 @@
 
 // Initialize and destroy the event timers once
 void test_stopwatch_setup_teardown() {
-  const enum StopwatchEvents events[] = {TOTAL_CYCLES, L1_CACHE_MISS};
-  const unsigned int num_events = 2;
-  assert(stopwatch_init(events, num_events) == STOPWATCH_OK);
+  assert(stopwatch_init() == STOPWATCH_OK);
   stopwatch_destroy();
 }
 
 // Initialize and destroy the event timers multiple times. This will assure that paired calls to `init_event_timers` and
 // `destroy_event_timers` should always succeed.
 void test_stopwatch_setup_teardown_multiple_times() {
-  const enum StopwatchEvents events[] = {TOTAL_CYCLES, L1_CACHE_MISS};
-  const unsigned int num_events = 2;
 // Call `init_event_timer` and `destroy_event_timer`
   const int max_iterations = 10;
   for (int i = 0; i < max_iterations; i++) {
-    assert(stopwatch_init(events, num_events) == STOPWATCH_OK);
+    assert(stopwatch_init() == STOPWATCH_OK);
     stopwatch_destroy();
   }
 }
@@ -29,10 +25,8 @@ void test_stopwatch_setup_teardown_multiple_times() {
 // This test case aims to mimic the situation where the event timers have already be initialized and there is another
 // call to initialize the event timers.
 void test_stopwatch_setup_twice() {
-  const enum StopwatchEvents events[] = {TOTAL_CYCLES, L1_CACHE_MISS};
-  const unsigned int num_events = 2;
-  assert(stopwatch_init(events, num_events) == STOPWATCH_OK);
-  assert(stopwatch_init(events, num_events) == STOPWATCH_ERR);
+  assert(stopwatch_init() == STOPWATCH_OK);
+  assert(stopwatch_init() == STOPWATCH_ERR);
   stopwatch_destroy();
 }
 

--- a/test/stopwatch_measurement_tests.c
+++ b/test/stopwatch_measurement_tests.c
@@ -23,9 +23,7 @@ void test_stopwatch_perf_mat_mul() {
   }
   memset(C, 0, sizeof(float) * N * N);
 
-  const enum StopwatchEvents events[] = {L1_CACHE_MISS, CYCLES_STALLED_RESOURCE};
-  const unsigned int num_events = 2;
-  assert(stopwatch_init(events, num_events) == STOPWATCH_OK);
+  assert(stopwatch_init() == STOPWATCH_OK);
   assert(stopwatch_record_start_measurements(1, "mat-mul", 0) == STOPWATCH_OK);
   row_major(N, A, B, C);
   assert(stopwatch_record_end_measurements(1) == STOPWATCH_OK);
@@ -41,22 +39,17 @@ void test_stopwatch_perf_mat_mul() {
   // accurately check these values while also being hardware independent.
   assert(result.total_real_cyc > 0);
   assert(result.total_real_usec > 0);
-  assert(result.total_event_values[0] > 0); // L1 cache misses
-  assert(result.total_event_values[1] > 0); // Total cycles stalled waiting on resources
+  assert(result.total_event_values[0] > 0); // Total cycles
+  assert(result.total_event_values[1] > 0); // Total instructions
 
   assert(result.total_times_called == 1);
-
-  // the total amount of cpu cycles should always be greater than the cycles waiting for resources, otherwise the cpu
-  // does no work which cannot be as floating point operations are being performed.
-  assert(result.total_real_cyc > result.total_event_values[1]);
 
   stopwatch_destroy();
 }
 
 // Repeatedly does the same matrix multiplication to test the accumulation feature
 void test_stopwatch_perf_mat_mul_loop() {
-  const enum StopwatchEvents events[] = {CYCLES_STALLED_RESOURCE, L1_CACHE_MISS};
-  assert(stopwatch_init(events, 2) == STOPWATCH_OK);
+  assert(stopwatch_init() == STOPWATCH_OK);
 
   int N = 1000;
   int itercount = 10;
@@ -119,14 +112,12 @@ void test_stopwatch_perf_mat_mul_loop() {
   assert(total_loop.total_event_values[0] > 0);
   assert(total_loop.total_event_values[1] > 0);
   assert(total_loop.total_times_called == 1);
-  assert(total_loop.total_real_cyc > total_loop.total_event_values[1]);
 
   assert(single_cycle.total_real_cyc > 0);
   assert(single_cycle.total_real_usec > 0);
   assert(single_cycle.total_event_values[0] > 0);
   assert(single_cycle.total_event_values[1] > 0);
   assert(single_cycle.total_times_called == itercount);
-  assert(single_cycle.total_real_cyc > single_cycle.total_event_values[1]);
 
   //Also the outer loop values should be approximately the same as the accumulated inner loop values.
   // At the moment a 5% error will be considered acceptable


### PR DESCRIPTION
Event sets to be measured no longer require a recompilation. Instead they are set by an environment variable that is read at runtime.